### PR TITLE
Add cablintd.

### DIFF
--- a/bin/cablintd
+++ b/bin/cablintd
@@ -1,0 +1,26 @@
+#!/usr/bin/ruby -Eutf-8:utf-8
+# encoding: UTF-8
+# Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#   http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+require 'certlint'
+require 'socket'
+
+Socket.unix_server_loop("/tmp/cablint.socket" + ARGV[0]) {|socket|
+  begin
+    CertLint::CABLint.lint(socket.read).each do |msg|
+      socket.puts "#{msg}"
+    end
+  ensure
+    socket.close
+  end
+}

--- a/bin/cablintd
+++ b/bin/cablintd
@@ -15,7 +15,7 @@
 require 'certlint'
 require 'socket'
 
-Socket.unix_server_loop("/tmp/cablint.socket" + ARGV[0]) {|socket|
+Socket.unix_server_loop("/tmp/cablint.socket" + (ARGV[0] ? ARGV[0] : "1")) {|socket|
   begin
     CertLint::CABLint.lint(socket.read).each do |msg|
       socket.puts "#{msg}"

--- a/start_cablintd.sh
+++ b/start_cablintd.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+for i in `seq 1 $1`;
+do
+  ruby -I /usr/local/certlint/lib /usr/local/certlint/bin/cablintd $i &
+done
+
+sleep 3
+
+for i in `seq 1 $1`;
+do
+  chmod 666 /tmp/cablint.socket$i
+done


### PR DESCRIPTION
cablintd makes cablint accessible over a unix socket, avoiding the need to startup a new Ruby process each time.

For https://crt.sh/?cablint=1+week I'm running cablint on each newly encountered cert.  And whenever you update cablint, I ideally need to re-run it on all previously logged certs!  crt.sh is processing certs 10x to 20x quicker using cablintd instead of cablint.

cablintd isn't the optimal solution (turning cablint into a shared library would be much better), so I won't be offended if you reject this PR.  :-)
