### PR TITLE
GeneralNames::lint should always return an array

### DIFF
--- a/lib/certlint/generalnames.rb
+++ b/lib/certlint/generalnames.rb
@@ -69,7 +69,7 @@ module CertLint
         # If the local part is nil (e.g. name constraint)
         # don't do checks on it
         if local_part.nil?
-          return
+          return []
         end
 
         if local_part.empty?


### PR DESCRIPTION
Otherwise, running cablint fails on this certificate:

-----BEGIN CERTIFICATE-----
MIIFDTCCBJKgAwIBAgIIHLxkVswit4owCgYIKoZIzj0EAwIwgaoxCzAJBgNVBAYT
AkdSMQ8wDQYDVQQHEwZBdGhlbnMxRDBCBgNVBAoTO0hlbGxlbmljIEFjYWRlbWlj
IGFuZCBSZXNlYXJjaCBJbnN0aXR1dGlvbnMgQ2VydC4gQXV0aG9yaXR5MUQwQgYD
VQQDEztIZWxsZW5pYyBBY2FkZW1pYyBhbmQgUmVzZWFyY2ggSW5zdGl0dXRpb25z
IEVDQyBSb290Q0EgMjAxNTAeFw0xNTA3MjgwODE3NThaFw0yMzA3MjYwODE3NTha
MIGYMQswCQYDVQQGEwJHUjFEMEIGA1UEChM7SGVsbGVuaWMgQWNhZGVtaWMgYW5k
IFJlc2VhcmNoIEluc3RpdHV0aW9ucyBDZXJ0LiBBdXRob3JpdHkxQzBBBgNVBAMT
OkhlbGxlbmljIEFjYWRlbWljIGFuZCBSZXNlYXJjaCBJbnN0aXR1dGlvbnMgRUND
IEFkbWluQ0EgUjEwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAASQIIVXsHoO2Gu9qbik
KEzzZXdkTyZb9CqH+B+TqJQ2yS/fkxeVt9z7gNL2sM4JU/lcZQUzEnOfnPb6RclD
/XoIpMiebkx7bs/1jK5Cumfu3DQlhK0wuGWmwXi/jKU4gc6jggKTMIICjzAPBgNV
HRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUmNs/pRHT1lyj
Z3Rmy0f0IMiloIIwSQYDVR0fBEIwQDA+oDygOoY4aHR0cDovL2NybHYxLmhhcmlj
YS5nci9IYXJpY2FFQ0NSb290Q0EyMDE1L2NybHYxLmRlci5jcmwwHwYDVR0jBBgw
FoAUtCILgpkkAQ6cu+QO/b/7lyCTmSowcQYIKwYBBQUHAQEEZTBjMCEGCCsGAQUF
BzABhhVodHRwOi8vb2NzcC5oYXJpY2EuZ3IwPgYIKwYBBQUHMAKGMmh0dHA6Ly93
d3cuaGFyaWNhLmdyL2NlcnRzL0hhcmljYUVDQ1Jvb3RDQTIwMTUuY3J0MIIBNwYD
VR0gBIIBLjCCASowggEmBgRVHSAAMIIBHDAyBggrBgEFBQcCARYmaHR0cDovL3d3
dy5oYXJpY2EuZ3IvZG9jdW1lbnRzL0NQUy5waHAwgeUGCCsGAQUFBwICMIHYMEoW
Q0hlbGxlbmljIEFjYWRlbWljIGFuZCBSZXNlYXJjaCBJbnN0aXR1dGlvbnMgQ2Vy
dGlmaWNhdGlvbiBBdXRob3JpdHkwAwIBARqBiVRoaXMgY2VydGlmaWNhdGUgaXMg
c3ViamVjdCB0byBHcmVlayBsYXdzIGFuZCBvdXIgQ1BTLiBUaGlzIENlcnRpZmlj
YXRlIG11c3Qgb25seSBiZSB1c2VkIGZvciBhY2FkZW1pYywgcmVzZWFyY2ggb3Ig
ZWR1Y2F0aW9uYWwgcHVycG9zZXMuMDMGA1UdHgQsMCqgKDALggloYXJpY2EuZ3Iw
C4EJaGFyaWNhLmdyMAyBCi5oYXJpY2EuZ3IwCgYIKoZIzj0EAwIDaQAwZgIxALPe
fD3HYnqhH0Cpj3SXdZVs66bcXBd6YexR0JcZvJWNz4ZhU/fYHWcnsm5kc+6qjwIx
APKgGgCcma2JgWE9OJdK9CuC7hv83wv4ijjjr30YX8KeVrbv1MCn2l71aoh3gbUH
lw==
-----END CERTIFICATE-----
