### PR TITLE
handle empty AIA and (deprecated) subject names

### DIFF
--- a/lib/certlint/cablint.rb
+++ b/lib/certlint/cablint.rb
@@ -360,7 +360,7 @@ module CertLint
 
         aia = c.extensions.find { |ex| ex.oid == 'authorityInfoAccess' }
         if aia.nil?
-          messages << 'E: BR certificates must include authorityInformationAccess'
+          messages << 'W: Certificate does not include authorityInformationAccess. BRs require OCSP stapling for this certificate.'
         else
           aia_info = aia.value.split(/\n/)
           unless aia_info.any? { |i| i.start_with? 'OCSP - URI:http://' }

--- a/lib/certlint/namelint.rb
+++ b/lib/certlint/namelint.rb
@@ -274,7 +274,11 @@ module CertLint
       begin
         name.to_s(OpenSSL::X509::Name::RFC2253 & ~4)
       rescue OpenSSL::X509::NameError => e
-        messages << "E: Unparsable name: #{e.message}"
+        if(name.to_s.empty?)
+          messages << "N: Empty Subject Name, some applications require a CN"
+        else
+          messages << "E: Unparsable name: #{e.message}"
+        end
       end
 
       messages


### PR DESCRIPTION
fixes bug when empty subjects are encountered. (details in commit comment)